### PR TITLE
Fix merge when iterator contains Stats with count of zero

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,5 +145,15 @@ mod tests {
 
         assert!(s.mean.approx_eq_ulps(&3.0, 2));
         assert!(s.std_dev.approx_eq_ulps(&1.5811388, 2));
+        
+        let s2: Stats<f32> = Stats::new();
+        let s3 = Stats::<f32>::merge(vec![s, s2].into_iter());
+        assert_eq!(s3.count, vals.len());
+        
+        assert_eq!(s3.min, 1.0);
+        assert_eq!(s3.max, 5.0);
+        
+        assert!(s3.mean.approx_eq_ulps(&3.0, 2));
+        assert!(s3.std_dev.approx_eq_ulps(&1.5811388, 2));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,7 +94,11 @@ where
     pub fn merge<S: Iterator<Item = Stats<T>>>(stats: S) -> Stats<T> {
         let mut merged = Stats::new();
 
-        for s in stats {
+        for s in stats {        
+            if s.count == 0 {
+                continue
+            }
+
             // Track min and max
             if s.max > merged.max || merged.count == 0 {
                 merged.max = s.max;


### PR DESCRIPTION
`merge` does not properly handles updating `merged.max` and `merged.min` when `s.count == 0`. This PR fixes this bug.