### PR TITLE
Fix merge bug and other enhancements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,17 @@
 [package]
-authors = ["Ryan Kurte <ryankurte@gmail.com>"]
+authors = [
+  "Ryan Kurte <ryankurte@gmail.com>",
+  "Dilshod Tadjibaev @antimora",
+]
+categories = ["science"]
 description = "Rolling statistics calculations (min/max/mean/std_dev) over arbitrary floating point numbers based on Welford's Online Algorithm"
-edition = "2018"
+edition = "2021"
+keywords = ["statistics", "stats", "data"]
 license = "MIT / Apache-2.0"
 name = "rolling-stats"
+readme = "README.md"
 repository = "https://github.com/ryankurte/rust-rolling-stats"
-version = "0.6.0"
+version = "0.7.0"
 
 [features]
 default = ["std"]
@@ -14,9 +20,12 @@ std = [
 ]
 
 [dependencies]
-libm = {version = "0.2.0", optional = true}
-num-traits = {version = "0.2.15", default-features = false, features = ["libm"] }
-serde = {version = "1.0.163", features = ["derive"], optional = true}
+libm = {version = "0.2.7", optional = true}
+num-traits = {version = "0.2.15", default-features = false, features = ["libm"]}
+serde = {version = "1.0.163", features = ["derive"], optional = true, default-features = false}
 
 [dev-dependencies]
 float-cmp = "0.9.0"
+rand = "0.8.5"
+rand_distr = "0.4.3"
+rayon = "1.7.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,15 +1,22 @@
 [package]
-name = "rolling-stats"
-version = "0.6.0"
-description = "Rolling statistics calculations (min/max/mean/std_dev) over arbitrary floating point numbers based on Welford's Online Algorithm"
 authors = ["Ryan Kurte <ryankurte@gmail.com>"]
-repository = "https://github.com/ryankurte/rust-rolling-stats"
+description = "Rolling statistics calculations (min/max/mean/std_dev) over arbitrary floating point numbers based on Welford's Online Algorithm"
 edition = "2018"
 license = "MIT / Apache-2.0"
+name = "rolling-stats"
+repository = "https://github.com/ryankurte/rust-rolling-stats"
+version = "0.6.0"
+
+[features]
+default = ["std"]
+std = [
+  "num-traits/std",
+]
 
 [dependencies]
-num-traits = "0.2.6"
-serde = { version = "1.0.94", features = ["derive"], optional = true }
+libm = {version = "0.2.0", optional = true}
+num-traits = {version = "0.2.15", default-features = false, features = ["libm"] }
+serde = {version = "1.0.163", features = ["derive"], optional = true}
 
 [dev-dependencies]
-float-cmp = "0.4.0"
+float-cmp = "0.9.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,12 +13,6 @@ readme = "README.md"
 repository = "https://github.com/ryankurte/rust-rolling-stats"
 version = "0.7.0"
 
-[features]
-default = ["std"]
-std = [
-  "num-traits/std",
-]
-
 [dependencies]
 libm = {version = "0.2.7", optional = true}
 num-traits = {version = "0.2.15", default-features = false, features = ["libm"]}

--- a/README.md
+++ b/README.md
@@ -1,24 +1,117 @@
-# rust-rolling-stats
+# Rust-Rolling-Stats
 
-Rolling statistics calculations (min/max/mean/std_dev) over arbitrary floating point numbers based
-on Welford's Online Algorithm.
+The `rolling-stats` library offers rolling statistics calculations (minimum, maximum, mean, standard
+deviation) over arbitrary floating point numbers. It uses Welford's Online Algorithm for these
+computations.
 
-See https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance for more information
+For more information on the algorithm, visit
+[Algorithms for calculating variance](https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance)
+on Wikipedia.
 
 ## Status
 
 [![GitHub tag](https://img.shields.io/github/tag/ryankurte/rust-rolling-stats.svg)](https://github.com/ryankurte/rust-rolling-stats)
 [![Build Status](https://travis-ci.com/ryankurte/rust-rolling-stats.svg?branch=master)](https://travis-ci.com/ryankurte/rust-rolling-stats)
-[![Crates.io](https://img.shields.io/crates/v/drolling-stats.svg)](https://crates.io/crates/drolling-stats)
-[![Docs.rs](https://docs.rs/drolling-stats/badge.svg)](https://docs.rs/drolling-stats)
+[![Crates.io](https://img.shields.io/crates/v/rolling-stats.svg)](https://crates.io/crates/rolling-stats)
+[![Docs.rs](https://docs.rs/rolling-stats/badge.svg)](https://docs.rs/rolling-stats)
 
-## no_std
+## Usage
+
+### Single Thread Example
+
+Below is an example of using `rust-rolling-stats` in a single-threaded context:
+
+```rust
+use rolling_stats::Stats;
+use rand_distr::{Distribution, Normal};
+use rand::SeedableRng;
+
+type T = f64;
+
+const MEAN: T = 0.0;
+const STD_DEV: T = 1.0;
+const NUM_SAMPLES: usize = 10_000;
+const SEED: u64 = 42;
+
+let mut stats: Stats<T> = Stats::new();
+let mut rng = rand::rngs::StdRng::seed_from_u64(SEED); // Seed the RNG for reproducibility
+let normal = Normal::<T>::new(MEAN, STD_DEV).unwrap();
+
+// Generate random data
+let random_data: Vec<T> = (0..NUM_SAMPLES).map(|_x| normal.sample(&mut rng)).collect();
+
+// Update the stats one by one
+random_data.iter().for_each(|v| stats.update(*v));
+
+// Print the stats
+println!("{}", stats);
+// Output: (avg: 0.00, std_dev: 1.00, min: -3.53, max: 4.11, count: 10000)
+```
+
+### Multi Thread Example
+
+This example showcases the usage of `rust-rolling-stats` in a multi-threaded context with the help
+of the `rayon` crate:
+
+```rust
+use rolling_stats::Stats;
+use rand_distr::{Distribution, Normal};
+use rand::SeedableRng;
+use rayon::prelude::*;
+
+type T = f64;
+
+const MEAN: T = 0.0;
+const STD_DEV: T = 1.0;
+const NUM_SAMPLES: usize = 500_000;
+const SEED: u64 = 42;
+const CHUNK_SIZE: usize = 1000;
+
+let mut stats: Stats<T> = Stats::new();
+let mut rng = rand::rngs::StdRng::seed_from_u64(SEED); // Seed the RNG for reproducibility
+let normal = Normal::<T>::new(MEAN, STD_DEV).unwrap();
+
+// Generate random data
+let random_data: Vec<T> = (0..NUM_SAMPLES).map(|_x| normal.sample(&mut rng)).collect();
+
+// Update the stats in parallel. New stats objects are created for each chunk of data.
+let stats: Vec<Stats<T>> = random_data
+    .par_chunks(CHUNK_SIZE) // Multi-threaded parallelization via Rayon
+    .map(|chunk| {
+        let mut s: Stats<T> = Stats::new();
+        chunk.iter().for_each(|v| s.update(*v));
+        s
+    })
+    .collect();
+
+// Check if there's more than one stat object
+assert!(stats.len() > 1);
+
+// Accumulate the stats using the reduce method
+let merged_stats = stats.into_iter().reduce(|acc, s| acc.merge(&s)).unwrap();
+
+// Print the stats
+println!("{}", merged_stats);
+// Output: (avg: -0.00, std_dev: 1.00, min: -4.53, max: 4.57, count: 500000)
+```
+
+## Feature Flags
+
+The following feature flags are available:
+
+- `std`: Enables the `std` crate. Enabled by default.
+- `serde`: Enables serialization and deserialization of the `Stats` struct via the `serde` crate.
+
+## `no_std` Compatibility
 
 This crate is `no_std` compatible, simply disable the default features in your `Cargo.toml`:
 
 ```toml
-
 [dependencies]
-rolling-stats = { version = "0.6.0", default-features = false }
-
+rolling-stats = { version = "0.7.0", default-features = false }
 ```
+
+## License
+
+The `rolling-stats` library is dual-licensed under the MIT and Apache License 2.0. By opening a pull
+request, you are implicitly agreeing to these licensing terms.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # rust-rolling-stats
 
-Rolling statistics calculations (min/max/mean/std_dev) over arbitrary floating point numbers based on Welford's Online Algorithm.
+Rolling statistics calculations (min/max/mean/std_dev) over arbitrary floating point numbers based
+on Welford's Online Algorithm.
 
 See https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance for more information
 
@@ -11,3 +12,13 @@ See https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance for more i
 [![Crates.io](https://img.shields.io/crates/v/drolling-stats.svg)](https://crates.io/crates/drolling-stats)
 [![Docs.rs](https://docs.rs/drolling-stats/badge.svg)](https://docs.rs/drolling-stats)
 
+## no_std
+
+This crate is `no_std` compatible, simply disable the default features in your `Cargo.toml`:
+
+```toml
+
+[dependencies]
+rolling-stats = { version = "0.6.0", default-features = false }
+
+```

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The `rolling-stats` library offers rolling statistics calculations (minimum, maximum, mean, standard
 deviation) over arbitrary floating point numbers. It uses Welford's Online Algorithm for these
-computations.
+computations. This crate is `no_std` compatible.
 
 For more information on the algorithm, visit
 [Algorithms for calculating variance](https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance)
@@ -99,17 +99,7 @@ println!("{}", merged_stats);
 
 The following feature flags are available:
 
-- `std`: Enables the `std` crate. Enabled by default.
 - `serde`: Enables serialization and deserialization of the `Stats` struct via the `serde` crate.
-
-## `no_std` Compatibility
-
-This crate is `no_std` compatible, simply disable the default features in your `Cargo.toml`:
-
-```toml
-[dependencies]
-rolling-stats = { version = "0.7.0", default-features = false }
-```
 
 ## License
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 
 extern crate alloc;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,7 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
+extern crate alloc;
+
 use core::fmt::Debug;
 use core::ops::AddAssign;
 
@@ -93,9 +97,9 @@ where
     pub fn merge<S: Iterator<Item = Stats<T>>>(stats: S) -> Stats<T> {
         let mut merged = Stats::new();
 
-        for s in stats {        
+        for s in stats {
             if s.count == 0 {
-                continue
+                continue;
             }
 
             // Track min and max
@@ -129,6 +133,8 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloc::vec;
+    use alloc::vec::Vec;
 
     use float_cmp::ApproxEqUlps;
 
@@ -148,14 +154,14 @@ mod tests {
 
         assert!(s.mean.approx_eq_ulps(&3.0, 2));
         assert!(s.std_dev.approx_eq_ulps(&1.5811388, 2));
-        
+
         let s2: Stats<f32> = Stats::new();
         let s3 = Stats::<f32>::merge(vec![s, s2].into_iter());
         assert_eq!(s3.count, vals.len());
-        
+
         assert_eq!(s3.min, 1.0);
         assert_eq!(s3.max, 5.0);
-        
+
         assert!(s3.mean.approx_eq_ulps(&3.0, 2));
         assert!(s3.std_dev.approx_eq_ulps(&1.5811388, 2));
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,44 +2,79 @@
 
 extern crate alloc;
 
-use core::fmt::Debug;
-use core::ops::AddAssign;
+use core::{
+    fmt::{self, Debug},
+    ops::AddAssign,
+};
 
 use num_traits::{cast::FromPrimitive, float::Float, identities::One, identities::Zero};
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
-/// Stats object calculates continuous min/max/mean/deviation for tracking of time varying statistics.
+/// A statistics object that continuously calculates min, max, mean, and deviation for tracking time-varying statistics.
+/// Utilizes Welford's Online algorithm. More details on the algorithm can be found at:
+/// "https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Welford's_online_algorithm"
 ///
-/// See: https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Welford's_Online_algorithm for
-/// Details of the underlying algorithm.
+///
+/// # Example
+///
+/// ```
+/// use rolling_stats::Stats;
+/// use rand_distr::{Distribution, Normal};
+/// use rand::SeedableRng;
+///
+/// type T = f64;
+///
+/// const MEAN: T = 0.0;
+/// const STD_DEV: T = 1.0;
+/// const NUM_SAMPLES: usize = 10_000;
+/// const SEED: u64 = 42;
+///
+/// let mut stats: Stats<T> = Stats::new();
+/// let mut rng = rand::rngs::StdRng::seed_from_u64(SEED); // Seed the RNG for reproducibility
+/// let normal = Normal::<T>::new(MEAN, STD_DEV).unwrap();
+///
+/// // Generate random data
+/// let random_data: Vec<T> = (0..NUM_SAMPLES).map(|_x| normal.sample(&mut rng)).collect();
+///
+/// // Update the stats one by one
+/// random_data.iter().for_each(|v| stats.update(*v));
+///
+/// // Print the stats
+/// println!("{}", stats);
+/// // Output: (avg: 0.00, std_dev: 1.00, min: -3.53, max: 4.11, count: 10000)
+///
+/// ```
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct Stats<T: Float + Zero + One + AddAssign + FromPrimitive + PartialEq + Debug> {
-    /// Minimum value
+    /// The smallest value seen so far.
     pub min: T,
-    /// Maximum value
+
+    /// The largest value seen so far.
     pub max: T,
-    /// Mean of sample set
+
+    /// The calculated mean (average) of all the values seen so far.
     pub mean: T,
-    /// Standard deviation of sample
+
+    /// The calculated standard deviation of all the values seen so far.
     pub std_dev: T,
 
-    /// Number of values collected
+    /// The count of the total values seen.
     pub count: usize,
 
-    /// Internal mean squared for algo
+    /// The square of the mean value. This is an internal value used in the calculation of the standard deviation.
     #[cfg_attr(feature = "serde", serde(skip))]
     mean2: T,
 }
 
-use core::fmt;
-
+/// Implementing the Display trait for the Stats struct to present the statistics in a readable format.
 impl<T> fmt::Display for Stats<T>
 where
     T: fmt::Display + Float + Zero + One + AddAssign + FromPrimitive + PartialEq + Debug,
 {
+    /// Formats the output of the statistics.
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let precision = f.precision().unwrap_or(2);
 
@@ -51,38 +86,38 @@ impl<T> Stats<T>
 where
     T: Float + Zero + One + AddAssign + FromPrimitive + PartialEq + Debug,
 {
-    /// Create a new stats object
+    /// Creates a new stats object with all values set to their initial states.
     pub fn new() -> Stats<T> {
         Stats {
             count: 0,
-            min: T::zero(),
-            max: T::zero(),
+            min: T::infinity(),
+            max: T::neg_infinity(),
             mean: T::zero(),
             std_dev: T::zero(),
             mean2: T::zero(),
         }
     }
 
-    /// Update the stats object
+    /// Updates the stats object with a new value. The statistics are recalculated using the new value.
     pub fn update(&mut self, value: T) {
         // Track min and max
-        if value > self.max || self.count == 0 {
+        if value > self.max {
             self.max = value;
         }
-        if value < self.min || self.count == 0 {
+        if value < self.min {
             self.min = value;
         }
 
         // Increment counter
         self.count += 1;
-        let count = T::from_usize(self.count).unwrap();
+        let count = T::from(self.count).unwrap();
 
         // Calculate mean
-        let delta: T = value - self.mean;
+        let delta = value - self.mean;
         self.mean += delta / count;
 
         // Mean2 used internally for standard deviation calculation
-        let delta2: T = value - self.mean;
+        let delta2 = value - self.mean;
         self.mean2 += delta * delta2;
 
         // Calculate standard deviation
@@ -91,40 +126,98 @@ where
         }
     }
 
-    /// Merge a set of stats objects for analysis
-    /// This performs a weighted averaging across the provided stats object, the output
-    /// object should not be updated further.
-    pub fn merge<S: Iterator<Item = Stats<T>>>(stats: S) -> Stats<T> {
-        let mut merged = Stats::new();
+    /// Merges another stats object into new one. This is done by combining the statistics of the two objects
+    /// in accordance with the formula provided at:
+    /// https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Parallel_algorithm
+    ///
+    /// This is useful for combining statistics from multiple threads or processes.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use rolling_stats::Stats;
+    /// use rand_distr::{Distribution, Normal};
+    /// use rand::SeedableRng;
+    /// use rayon::prelude::*;
+    ///
+    /// type T = f64;
+    ///
+    /// const MEAN: T = 0.0;
+    /// const STD_DEV: T = 1.0;
+    /// const NUM_SAMPLES: usize = 500_000;
+    /// const SEED: u64 = 42;
+    /// const CHUNK_SIZE: usize = 1000;
+    ///
+    /// let mut stats: Stats<T> = Stats::new();
+    /// let mut rng = rand::rngs::StdRng::seed_from_u64(SEED); // Seed the RNG for reproducibility
+    /// let normal = Normal::<T>::new(MEAN, STD_DEV).unwrap();
+    ///
+    /// // Generate random data
+    /// let random_data: Vec<T> = (0..NUM_SAMPLES).map(|_x| normal.sample(&mut rng)).collect();
+    ///
+    /// // Update the stats in parallel. New stats objects are created for each chunk of data.
+    /// let stats: Vec<Stats<T>> = random_data
+    ///     .par_chunks(CHUNK_SIZE) // Multi-threaded parallelization via Rayon
+    ///     .map(|chunk| {
+    ///             let mut s: Stats<T> = Stats::new();
+    ///             chunk.iter().for_each(|v| s.update(*v));
+    ///             s
+    ///      })
+    ///     .collect();
+    ///
+    /// // Check if there's more than one stat object
+    /// assert!(stats.len() > 1);
+    ///
+    /// // Accumulate the stats using the reduce method. The last stats object is returned.
+    /// let merged_stats = stats.into_iter().reduce(|acc, s| acc.merge(&s)).unwrap();
+    ///
+    /// // Print the stats
+    /// println!("{}", merged_stats);
+    ///
+    /// // Output: (avg: -0.00, std_dev: 1.00, min: -4.53, max: 4.57, count: 500000)
+    ///```
+    pub fn merge(&self, other: &Self) -> Self {
+        let mut merged = Stats::<T>::new();
 
-        for s in stats {
-            if s.count == 0 {
-                continue;
-            }
-
-            // Track min and max
-            if s.max > merged.max || merged.count == 0 {
-                merged.max = s.max;
-            }
-            if s.min < merged.min || merged.count == 0 {
-                merged.min = s.min;
-            }
-
-            let merged_count = T::from_usize(merged.count).unwrap();
-            let s_count = T::from_usize(s.count).unwrap();
-
-            if merged.count > 0 {
-                merged.mean =
-                    (merged.mean * merged_count + s.mean * s_count) / (merged_count + s_count);
-                merged.std_dev = (merged.std_dev * merged_count + s.std_dev * s_count)
-                    / (merged_count + s_count);
-                merged.count += s.count;
-            } else {
-                merged.mean = s.mean;
-                merged.std_dev = s.std_dev;
-                merged.count = s.count;
-            }
+        // If both stats objects are empty, return an empty stats object
+        if self.count + other.count == 0 {
+            return merged;
         }
+
+        // If one of the stats objects is empty, return the other one
+        if self.count == 0 {
+            return other.clone();
+        } else if other.count == 0 {
+            return self.clone();
+        }
+
+        merged.max = if other.max > self.max {
+            other.max
+        } else {
+            self.max
+        };
+
+        merged.min = if other.min < self.min {
+            other.min
+        } else {
+            self.min
+        };
+
+        merged.count = self.count + other.count;
+
+        // Convert to T to avoid overflow
+        let merged_count = T::from(merged.count).unwrap();
+        let self_count = T::from(self.count).unwrap();
+        let other_count = T::from(other.count).unwrap();
+
+        let delta = other.mean - self.mean;
+
+        merged.mean = (self.mean * self_count + other.mean * other_count) / merged_count;
+
+        merged.mean2 =
+            self.mean2 + other.mean2 + delta * delta * self_count * other_count / merged_count;
+
+        merged.std_dev = (merged.mean2 / (merged_count - T::one())).sqrt();
 
         merged
     }
@@ -133,10 +226,16 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+
     use alloc::vec;
     use alloc::vec::Vec;
 
-    use float_cmp::ApproxEqUlps;
+    use float_cmp::{ApproxEq, ApproxEqUlps};
+    use rand::SeedableRng;
+    use rand_distr::{Distribution, Normal};
+    use rayon::prelude::*;
+
+    type T = f64;
 
     #[test]
     fn it_works() {
@@ -154,15 +253,221 @@ mod tests {
 
         assert!(s.mean.approx_eq_ulps(&3.0, 2));
         assert!(s.std_dev.approx_eq_ulps(&1.5811388, 2));
+    }
 
-        let s2: Stats<f32> = Stats::new();
-        let s3 = Stats::<f32>::merge(vec![s, s2].into_iter());
-        assert_eq!(s3.count, vals.len());
+    /// Calculate the mean of a vector of values
+    fn calc_mean(vals: &Vec<T>) -> T {
+        let sum = vals.iter().fold(T::zero(), |acc, x| acc + *x);
 
-        assert_eq!(s3.min, 1.0);
-        assert_eq!(s3.max, 5.0);
+        sum / T::from_usize(vals.len()).unwrap()
+    }
 
-        assert!(s3.mean.approx_eq_ulps(&3.0, 2));
-        assert!(s3.std_dev.approx_eq_ulps(&1.5811388, 2));
+    /// Calculate the standard deviation of a vector of values
+    fn calc_std_dev(vals: &Vec<T>) -> T {
+        let mean = calc_mean(vals);
+        let std_dev = (vals
+            .iter()
+            .fold(T::zero(), |acc, x| acc + (*x - mean).powi(2))
+            / T::from_usize(vals.len() - 1).unwrap())
+        .sqrt();
+
+        std_dev
+    }
+
+    /// Get the maximum value in a vector of values
+    fn get_max(vals: &Vec<T>) -> T {
+        let mut max = T::min_value();
+        for v in vals {
+            if *v > max {
+                max = *v;
+            }
+        }
+        max
+    }
+
+    /// Get the minimum value in a vector of values
+    fn get_min(vals: &Vec<T>) -> T {
+        let mut min = T::max_value();
+        for v in vals {
+            if *v < min {
+                min = *v;
+            }
+        }
+        min
+    }
+
+    #[test]
+    fn stats_for_large_random_data() {
+        // Define some constants
+        const MEAN: T = 2.0;
+        const STD_DEV: T = 3.0;
+        const SEED: u64 = 42;
+        const NUM_SAMPLES: usize = 10_000;
+
+        let mut s: Stats<T> = Stats::new();
+        let mut rng = rand::rngs::StdRng::seed_from_u64(SEED);
+
+        let normal = Normal::<T>::new(MEAN, STD_DEV).unwrap();
+
+        // Generate some random data
+        let random_data: Vec<T> = (0..NUM_SAMPLES).map(|_x| normal.sample(&mut rng)).collect();
+
+        // Update the stats
+        random_data.iter().for_each(|v| s.update(*v));
+
+        // Calculate the mean using sum/count method
+        let mean = calc_mean(&random_data);
+
+        // Check the mean value against the stats' mean value
+        assert!(s.mean.approx_eq(mean, (1.0e-13, 2)));
+
+        // Calculate the standard deviation
+        let std_dev = calc_std_dev(&random_data);
+
+        // Check the standard deviation against the stats' standard deviation
+        assert!(s.std_dev.approx_eq(std_dev, (1.0e-13, 2)));
+
+        // Check the count
+        assert_eq!(s.count, random_data.len());
+
+        // Find the max and min values
+        let max = get_max(&random_data);
+        let min = get_min(&random_data);
+
+        // Check the max and min values
+        assert_eq!(s.max, max);
+        assert_eq!(s.min, min);
+    }
+
+    #[test]
+    fn stats_merge() {
+        // Define some constants
+        const MEAN: T = 2.0;
+        const STD_DEV: T = 3.0;
+        const SEED: u64 = 42;
+        const NUM_SAMPLES: usize = 10_000;
+
+        let mut s: Stats<T> = Stats::new();
+        let mut rng = rand::rngs::StdRng::seed_from_u64(SEED);
+
+        let normal = Normal::<T>::new(MEAN, STD_DEV).unwrap();
+
+        // Generate some random data
+        let random_data: Vec<T> = (0..NUM_SAMPLES).map(|_x| normal.sample(&mut rng)).collect();
+
+        // Update the stats
+        random_data.iter().for_each(|v| s.update(*v));
+
+        // Calculate the stats using the aggregate method instead of the rolling method
+        let mean = calc_mean(&random_data);
+        let std_dev = calc_std_dev(&random_data);
+        let max = get_max(&random_data);
+        let min = get_min(&random_data);
+
+        let chunks_size = 1000;
+
+        let stats: Vec<Stats<T>> = random_data
+            .chunks(chunks_size)
+            .map(|chunk| {
+                let mut s: Stats<T> = Stats::new();
+                chunk.iter().for_each(|v| s.update(*v));
+                s
+            })
+            .collect();
+
+        assert_eq!(stats.len(), NUM_SAMPLES / chunks_size);
+
+        // Accumulate the stats
+        let merged_stats = stats.into_iter().reduce(|acc, s| acc.merge(&s)).unwrap();
+
+        // Check the stats against the aggregate stats (using sum/count method)
+        assert!(merged_stats.mean.approx_eq(mean, (1.0e-13, 2)));
+        assert!(merged_stats.std_dev.approx_eq(std_dev, (1.0e-13, 2)));
+        assert_eq!(merged_stats.max, max);
+        assert_eq!(merged_stats.min, min);
+        assert_eq!(merged_stats.count, NUM_SAMPLES);
+
+        // Check the stats against the merged stats object
+        assert!(merged_stats.mean.approx_eq(s.mean, (1.0e-13, 2)));
+        assert!(merged_stats.std_dev.approx_eq(s.std_dev, (1.0e-13, 2)));
+        assert_eq!(merged_stats.max, s.max);
+        assert_eq!(merged_stats.min, s.min);
+        assert_eq!(merged_stats.count, s.count);
+
+        // Check edge cases
+
+        // Check merging with an empty stats object
+        let empty_stats: Stats<T> = Stats::new();
+        let merged_stats = s.merge(&empty_stats);
+        assert_eq!(merged_stats.count, s.count);
+
+        // Check merging an empty stats object with a non-empty stats object
+        let empty_stats: Stats<T> = Stats::new();
+        let merged_stats = empty_stats.merge(&s);
+        assert_eq!(merged_stats.count, s.count);
+
+        // Check merging two empty stats objects
+        let empty_stats_1: Stats<T> = Stats::new();
+        let empty_stats_2: Stats<T> = Stats::new();
+
+        let merged_stats = empty_stats_1.merge(&empty_stats_2);
+        assert_eq!(merged_stats.count, 0);
+    }
+
+    #[test]
+    fn stats_merge_parallel() {
+        // Define some constants
+        const MEAN: T = 2.0;
+        const STD_DEV: T = 3.0;
+        const SEED: u64 = 42;
+        const NUM_SAMPLES: usize = 500_000;
+
+        let mut s: Stats<T> = Stats::new();
+        let mut rng = rand::rngs::StdRng::seed_from_u64(SEED);
+
+        let normal = Normal::<T>::new(MEAN, STD_DEV).unwrap();
+
+        // Generate some random data
+        let random_data: Vec<T> = (0..NUM_SAMPLES).map(|_x| normal.sample(&mut rng)).collect();
+
+        // Update the stats
+        random_data.iter().for_each(|v| s.update(*v));
+
+        // Calculate the stats using the aggregate method instead of the rolling method
+        let mean = calc_mean(&random_data);
+        let std_dev = calc_std_dev(&random_data);
+        let max = get_max(&random_data);
+        let min = get_min(&random_data);
+
+        let chunks_size = 1000;
+
+        let stats: Vec<Stats<T>> = random_data
+            .par_chunks(chunks_size) // <--- Parallelization by Rayon
+            .map(|chunk| {
+                let mut s: Stats<T> = Stats::new();
+                chunk.iter().for_each(|v| s.update(*v));
+                s
+            })
+            .collect();
+
+        // There should be more than one stat
+        assert!(stats.len() >= NUM_SAMPLES / chunks_size);
+
+        // Accumulate the stats
+        let merged_stats = stats.into_iter().reduce(|acc, s| acc.merge(&s)).unwrap();
+
+        // Check the stats against the aggregate stats (using sum/count method)
+        assert!(merged_stats.mean.approx_eq(mean, (1.0e-13, 2)));
+        assert!(merged_stats.std_dev.approx_eq(std_dev, (1.0e-13, 2)));
+        assert_eq!(merged_stats.max, max);
+        assert_eq!(merged_stats.min, min);
+        assert_eq!(merged_stats.count, NUM_SAMPLES);
+
+        // Check the stats against the merged stats object
+        assert!(merged_stats.mean.approx_eq(s.mean, (1.0e-13, 2)));
+        assert!(merged_stats.std_dev.approx_eq(s.std_dev, (1.0e-13, 2)));
+        assert_eq!(merged_stats.max, s.max);
+        assert_eq!(merged_stats.min, s.min);
+        assert_eq!(merged_stats.count, s.count);
     }
 }


### PR DESCRIPTION
## Pull Request Overview

This PR introduces a variety of enhancements and fixes:

1. Resolves issues #4 and #2.
2. Enhances functionality to support parallel computations with an updated `merge` method.
3. Updates README file to provide detailed examples and explanations.
4. Introduces comprehensive unit testing.
5. Optimizes the `update` method by removing unnecessary max/min count checks.
6. Adds compatibility with `no_std`.

I wanted to contribute these improvements to `rust-rolling-stats` because it's a library I frequently use, especially when dealing with large data sets. 

The primary motivation behind these changes is to ensure the `merge` method functions effectively in parallel computations. This is particularly crucial when computing the `mean` and `standard deviation` for large data sets (greater than 100GB). In my search, I found no other Rust library that's as simple and flexible as this one. Additionally, these updates ensure that the library operates successfully in a `no_std` environment, which will be particularly useful for stream processing in my upcoming projects. 

I hope you find these changes valuable. Please don't hesitate to reach out if you have any questions or need further information.